### PR TITLE
Fix unexpected token: 'as' compile time errors

### DIFF
--- a/src/webdriver.cr
+++ b/src/webdriver.cr
@@ -36,7 +36,7 @@ module Selenium
 
       case response.status_code
       when 200
-        JSON.parse(response.body).raw as Hash
+        JSON.parse(response.body).raw.as(Hash)
       else
         failure(response)
       end
@@ -50,10 +50,10 @@ module Selenium
 
     private def failure(response)
       if response.headers["Content-Type"].starts_with?("application/json")
-        body = JSON.parse(response.body).raw as Hash
-        status = body["status"] as Int
-        value = body["value"] as Hash
-        raise Selenium.error_class(status).new(value["message"] as String)
+        body = JSON.parse(response.body).raw.as(Hash)
+        status = body["status"].as(Int)
+        value = body["value"].as(Hash)
+        raise Selenium.error_class(status).new(value["message"].as(String))
       end
       raise Error.new(response.body)
     end

--- a/src/webdriver/alert.cr
+++ b/src/webdriver/alert.cr
@@ -6,7 +6,7 @@ module Selenium
     end
 
     def text
-      session.get("/alert_text") as String
+      session.get("/alert_text").as(String)
     end
 
     def send_keys(sequence : String)

--- a/src/webdriver/session.cr
+++ b/src/webdriver/session.cr
@@ -28,8 +28,8 @@ module Selenium
       }
       response = driver.post("/session", body)
 
-      @id = response["sessionId"] as String
-      @capabilities = response["value"] as Hash
+      @id = response["sessionId"].as(String)
+      @capabilities = response["value"].as(Hash)
 
       if url
         self.url = url
@@ -49,7 +49,7 @@ module Selenium
     end
 
     def url
-      get("/url") as String
+      get("/url").as(String)
     end
 
     def url=(url)
@@ -103,7 +103,7 @@ module Selenium
         using: WebElement.locator_for(by),
         value: selector
       })
-      WebElement.new(self, value as Hash)
+      WebElement.new(self, value.as(Hash))
     end
 
     def find_elements(by, selector, parent : WebElement = nil)
@@ -111,17 +111,17 @@ module Selenium
       value = post(url, {
         using: WebElement.locator_for(by),
         value: selector
-      }) as Array
-      value.map { |item| WebElement.new(self, item as Hash) }
+      }).as(Array)
+      value.map { |item| WebElement.new(self, item.as(Hash)) }
     end
 
     def active_element
       value = post("/element/active")
-      WebElement.new(self, value as Hash)
+      WebElement.new(self, value.as(Hash))
     end
 
     def orientation
-      get("/orientation") as String
+      get("/orientation").as(String)
     end
 
     def orientation=(value)

--- a/src/webdriver/web_element.cr
+++ b/src/webdriver/web_element.cr
@@ -63,7 +63,7 @@ module Selenium
     private getter session : Session
 
     def initialize(@session, item)
-      @id = item["ELEMENT"] as String
+      @id = item["ELEMENT"].as(String)
     end
 
     def find_element(by, selector)
@@ -75,15 +75,15 @@ module Selenium
     end
 
     def text
-      get("/text") as String
+      get("/text").as(String)
     end
 
     def name
-      get("/name") as String
+      get("/name").as(String)
     end
 
     def attribute(name)
-      get("/attribute/#{ name }") as String
+      get("/attribute/#{ name }").as(String)
     end
 
     def click
@@ -103,27 +103,27 @@ module Selenium
     end
 
     def ==(other : WebElement)
-      get("/equals/#{ other.id }") as Bool
+      get("/equals/#{ other.id }").as(Bool)
     end
 
     def displayed?
-      get("/displayed") as Bool
+      get("/displayed").as(Bool)
     end
 
     def location
-      get("/location") as Hash
+      get("/location").as(Hash)
     end
 
     def location_in_view
-      get("/location_in_view") as Hash
+      get("/location_in_view").as(Hash)
     end
 
     def size
-      get("/size") as Hash
+      get("/size").as(Hash)
     end
 
     def css(property)
-      get("/css/#{ property }") as String
+      get("/css/#{ property }").as(String)
     end
 
     def to_json(io)


### PR DESCRIPTION
`'<object> as <Type>'` is no longer allowed.
Use `'<object>.as(<Type>)'` method call instead.