### PR TITLE
Detect response success by looking in a status json field instead of response status_code

### DIFF
--- a/src/webdriver.cr
+++ b/src/webdriver.cr
@@ -31,12 +31,7 @@ module Selenium
       puts
       {% end %}
 
-      case response.status_code
-      when 200
-        JSON.parse(response.body)
-      else
-        failure(response)
-      end
+      handle_response(response)
     end
 
     def post(path, body = nil)
@@ -58,12 +53,7 @@ module Selenium
       puts
       {% end %}
 
-      case response.status_code
-      when 200
-        JSON.parse(response.body)
-      else
-        failure(response)
-      end
+      handle_response(response)
     end
 
     def delete(path)
@@ -82,13 +72,19 @@ module Selenium
       true
     end
 
-    private def failure(response)
+    private def handle_response(response)
       if response.headers["Content-Type"].starts_with?("application/json")
         body = JSON.parse(response.body)
         status = body["status"].as_i
-        raise Selenium.error_class(status).new(body["value"]["message"].as_s)
+
+        if status.zero?
+          body
+        else
+          raise Selenium.error_class(status).new(body["value"]["message"].as_s)
+        end
+      else
+        raise Error.new(response.body)
       end
-      raise Error.new(response.body)
     end
   end
 end


### PR DESCRIPTION
With chromedriver under linux, when element not found on page
response.status_code equals to 200, but status field non zero:

```
REQUEST: POST /session/c786d05c89dd776b7c13549a8f2d6d98/element/0.05628465599603438-1/element
{using: "css selector", value: "a[href='/some/unknown/link']"}
RESPONSE: 200
{"sessionId" => "c786d05c89dd776b7c13549a8f2d6d98", "status" => 7_i64, "value" => {"message" => "no such element: Unable to locate element: {\"method\":\"css selector\",\"selector\":\"a[href='/some/unknown/link']\"}\n  (Session info: chrome=67.0.3396.99)\n  (Driver info: chromedriver=2.38.552522 (437e6fbedfa8762dec75e2c5b3ddb86763dc9dcb),platform=Linux 4.13.0-45-generic x86_64)"}}
```

```
$ uname -a
Linux xps-13 4.13.0-45-generic #50~16.04.1-Ubuntu SMP Wed May 30 11:18:27 UTC 2018 x86_64 x86_64 x86_64 GNU/Linux
```

```
$ chromedriver --port=4444 --url-base=/wd/hub
Starting ChromeDriver 2.38.552522 (437e6fbedfa8762dec75e2c5b3ddb86763dc9dcb) on port 4444
```